### PR TITLE
Add serving size calculator to v60 app

### DIFF
--- a/app/(tool)/v60/components/brewing-process.tsx
+++ b/app/(tool)/v60/components/brewing-process.tsx
@@ -17,11 +17,11 @@ interface BrewingStep {
   gifUrl: string;
 }
 
-function getBrewingSteps(servings: number): BrewingStep[] {
+function getBrewingSteps(people: number): BrewingStep[] {
   return [
     {
       time: 0,
-      title: `Add ${servings * 60}g of water`,
+      title: `Add ${people * 30}g of water`,
       subTitle: "Wait until 0:45",
       hint: "This is the bloom phase. Be patient here. This is flavor town, baby 😋",
       gifUrl: "https://djg4kctbfokfu.cloudfront.net/tools/v60/bloom.gif",
@@ -29,14 +29,14 @@ function getBrewingSteps(servings: number): BrewingStep[] {
     {
       time: 45,
       title: "Pour water in circular motion",
-      subTitle: `Aim to reach ${servings * 300}g by 1:15`,
+      subTitle: `Aim to reach ${people * 150}g by 1:15`,
       hint: "This is somewhat fast pouring. Keep the water flow steady. No need to be perfect though 🙂.",
       gifUrl: "https://djg4kctbfokfu.cloudfront.net/tools/v60/initial-pour.gif",
     },
     {
       time: 75,
       title: "Continue pouring but slower",
-      subTitle: `Aim to reach ${servings * 500}g by 1:45`,
+      subTitle: `Aim to reach ${people * 250}g by 1:45`,
       hint: "Your cone should be quite full during this time. This helps to retain the heat ☕.",
       gifUrl: "https://djg4kctbfokfu.cloudfront.net/tools/v60/second-pour.gif",
     },
@@ -66,7 +66,7 @@ function getBrewingSteps(servings: number): BrewingStep[] {
 
 interface BrewingProcessProps {
   onRestart: () => void;
-  servings: number;
+  people: number;
 }
 
 const stepVariants = {
@@ -90,8 +90,8 @@ const stepTransition = {
   duration: 0.5,
 };
 
-export default function BrewingProcess({ onRestart, servings }: BrewingProcessProps) {
-  const brewingSteps = getBrewingSteps(servings);
+export default function BrewingProcess({ onRestart, people }: BrewingProcessProps) {
+  const brewingSteps = getBrewingSteps(people);
   const [time, setTime] = useState(0);
   const [isRunning, setIsRunning] = useState(false);
   const [currentStep, setCurrentStep] = useState(0);

--- a/app/(tool)/v60/components/brewing-process.tsx
+++ b/app/(tool)/v60/components/brewing-process.tsx
@@ -17,53 +17,56 @@ interface BrewingStep {
   gifUrl: string;
 }
 
-const brewingSteps: BrewingStep[] = [
-  {
-    time: 0,
-    title: "Add 60g of water",
-    subTitle: "Wait until 0:45",
-    hint: "This is the bloom phase. Be patient here. This is flavor town, baby 😋",
-    gifUrl: "https://djg4kctbfokfu.cloudfront.net/tools/v60/bloom.gif",
-  },
-  {
-    time: 45,
-    title: "Pour water in circular motion",
-    subTitle: "Aim to reach 300g by 1:15",
-    hint: "This is somewhat fast pouring. Keep the water flow steady. No need to be perfect though 🙂.",
-    gifUrl: "https://djg4kctbfokfu.cloudfront.net/tools/v60/initial-pour.gif",
-  },
-  {
-    time: 75,
-    title: "Continue pouring but slower",
-    subTitle: "Aim to reach 500g by 1:45",
-    hint: "Your cone should be quite full during this time. This helps to retain the heat ☕.",
-    gifUrl: "https://djg4kctbfokfu.cloudfront.net/tools/v60/second-pour.gif",
-  },
-  {
-    time: 105,
-    title: "Stir the coffee",
-    subTitle: "Stir once in both directions",
-    hint: "Make this a calm stir. No tornadoes, please 🌪️.",
-    gifUrl: "https://djg4kctbfokfu.cloudfront.net/tools/v60/stir.gif",
-  },
-  {
-    time: 120,
-    title: "Give it one last swirl",
-    subTitle: "Pick it up and swirl it in your hand",
-    hint: "After the coffee has drained a bit, give the cone a good swirl. We want a flat bed of coffee grounds to drain from.",
-    gifUrl: "https://djg4kctbfokfu.cloudfront.net/tools/v60/swirl.gif",
-  },
-  {
-    time: 135,
-    title: "Let it rest",
-    subTitle: "Let gravity do its thing",
-    hint: "You've done all the hard work. Congrats 🎊. Now just wait until all the coffee has drained.",
-    gifUrl: "https://djg4kctbfokfu.cloudfront.net/tools/v60/rest.gif",
-  },
-];
+function getBrewingSteps(servings: number): BrewingStep[] {
+  return [
+    {
+      time: 0,
+      title: `Add ${servings * 60}g of water`,
+      subTitle: "Wait until 0:45",
+      hint: "This is the bloom phase. Be patient here. This is flavor town, baby 😋",
+      gifUrl: "https://djg4kctbfokfu.cloudfront.net/tools/v60/bloom.gif",
+    },
+    {
+      time: 45,
+      title: "Pour water in circular motion",
+      subTitle: `Aim to reach ${servings * 300}g by 1:15`,
+      hint: "This is somewhat fast pouring. Keep the water flow steady. No need to be perfect though 🙂.",
+      gifUrl: "https://djg4kctbfokfu.cloudfront.net/tools/v60/initial-pour.gif",
+    },
+    {
+      time: 75,
+      title: "Continue pouring but slower",
+      subTitle: `Aim to reach ${servings * 500}g by 1:45`,
+      hint: "Your cone should be quite full during this time. This helps to retain the heat ☕.",
+      gifUrl: "https://djg4kctbfokfu.cloudfront.net/tools/v60/second-pour.gif",
+    },
+    {
+      time: 105,
+      title: "Stir the coffee",
+      subTitle: "Stir once in both directions",
+      hint: "Make this a calm stir. No tornadoes, please 🌪️.",
+      gifUrl: "https://djg4kctbfokfu.cloudfront.net/tools/v60/stir.gif",
+    },
+    {
+      time: 120,
+      title: "Give it one last swirl",
+      subTitle: "Pick it up and swirl it in your hand",
+      hint: "After the coffee has drained a bit, give the cone a good swirl. We want a flat bed of coffee grounds to drain from.",
+      gifUrl: "https://djg4kctbfokfu.cloudfront.net/tools/v60/swirl.gif",
+    },
+    {
+      time: 135,
+      title: "Let it rest",
+      subTitle: "Let gravity do its thing",
+      hint: "You've done all the hard work. Congrats 🎊. Now just wait until all the coffee has drained.",
+      gifUrl: "https://djg4kctbfokfu.cloudfront.net/tools/v60/rest.gif",
+    },
+  ];
+}
 
 interface BrewingProcessProps {
   onRestart: () => void;
+  servings: number;
 }
 
 const stepVariants = {
@@ -87,7 +90,8 @@ const stepTransition = {
   duration: 0.5,
 };
 
-export default function BrewingProcess({ onRestart }: BrewingProcessProps) {
+export default function BrewingProcess({ onRestart, servings }: BrewingProcessProps) {
+  const brewingSteps = getBrewingSteps(servings);
   const [time, setTime] = useState(0);
   const [isRunning, setIsRunning] = useState(false);
   const [currentStep, setCurrentStep] = useState(0);

--- a/app/(tool)/v60/components/starter-card.tsx
+++ b/app/(tool)/v60/components/starter-card.tsx
@@ -13,12 +13,13 @@ import Beans from "./illustrations/beans";
 import Kettle from "./illustrations/kettle";
 import Scale from "./illustrations/scale";
 import Cup from "./illustrations/cup";
-import { Coffee, ThumbsUp } from "lucide-react";
+import { Coffee, ThumbsUp, Minus, Plus } from "lucide-react";
 
 export default function StarterCard() {
   const [showInventory, setShowInventory] = useState(false);
   const [startBrewing, setStartBrewing] = useState(false);
   const [isScrollable, setIsScrollable] = useState(false);
+  const [servings, setServings] = useState(1);
   const contentRef = useRef<HTMLDivElement>(null);
 
   const inventoryItems = [
@@ -27,11 +28,11 @@ export default function StarterCard() {
       icon: <V60 className="w-12 h-12" />,
     },
     {
-      name: "30g of medium ground coffee",
+      name: `${servings * 30}g of medium ground coffee`,
       icon: <Beans className="w-12 h-12" />,
     },
     {
-      name: "500ml of hot water in kettle",
+      name: `${servings * 500}ml of hot water in kettle`,
       icon: <Kettle className="w-12 h-12" />,
     },
     { name: "Food scale", icon: <Scale className="w-12 h-12" /> },
@@ -58,7 +59,7 @@ export default function StarterCard() {
   };
 
   if (startBrewing) {
-    return <BrewingProcess onRestart={handleRestart} />;
+    return <BrewingProcess onRestart={handleRestart} servings={servings} />;
   }
 
   return (
@@ -88,6 +89,31 @@ export default function StarterCard() {
                   </a>{" "}
                   from James Hoffman.
                 </p>
+                <div className="flex flex-col items-center mb-8">
+                  <p className="text-sm text-[#6c6c6c] mb-3">How many cups?</p>
+                  <div className="flex items-center gap-4">
+                    <button
+                      onClick={() => setServings((s) => Math.max(1, s - 1))}
+                      disabled={servings === 1}
+                      className="w-9 h-9 rounded-full border border-[#8FA967] text-[#8FA967] flex items-center justify-center disabled:opacity-30 hover:bg-[#8FA967] hover:text-white transition-colors"
+                    >
+                      <Minus className="w-4 h-4" />
+                    </button>
+                    <span className="text-2xl font-bold text-[#4a4a4a] w-6 text-center">
+                      {servings}
+                    </span>
+                    <button
+                      onClick={() => setServings((s) => Math.min(4, s + 1))}
+                      disabled={servings === 4}
+                      className="w-9 h-9 rounded-full border border-[#8FA967] text-[#8FA967] flex items-center justify-center disabled:opacity-30 hover:bg-[#8FA967] hover:text-white transition-colors"
+                    >
+                      <Plus className="w-4 h-4" />
+                    </button>
+                  </div>
+                  <p className="text-xs text-[#9c9c9c] mt-2">
+                    {servings * 30}g coffee · {servings * 500}ml water
+                  </p>
+                </div>
               </>
             )}
             {!showInventory ? (

--- a/app/(tool)/v60/components/starter-card.tsx
+++ b/app/(tool)/v60/components/starter-card.tsx
@@ -19,7 +19,7 @@ export default function StarterCard() {
   const [showInventory, setShowInventory] = useState(false);
   const [startBrewing, setStartBrewing] = useState(false);
   const [isScrollable, setIsScrollable] = useState(false);
-  const [servings, setServings] = useState(1);
+  const [people, setPeople] = useState(2);
   const contentRef = useRef<HTMLDivElement>(null);
 
   const inventoryItems = [
@@ -28,11 +28,11 @@ export default function StarterCard() {
       icon: <V60 className="w-12 h-12" />,
     },
     {
-      name: `${servings * 30}g of medium ground coffee`,
+      name: `${people * 15}g of medium ground coffee`,
       icon: <Beans className="w-12 h-12" />,
     },
     {
-      name: `${servings * 500}ml of hot water in kettle`,
+      name: `${people * 250}ml of hot water in kettle`,
       icon: <Kettle className="w-12 h-12" />,
     },
     { name: "Food scale", icon: <Scale className="w-12 h-12" /> },
@@ -59,7 +59,7 @@ export default function StarterCard() {
   };
 
   if (startBrewing) {
-    return <BrewingProcess onRestart={handleRestart} servings={servings} />;
+    return <BrewingProcess onRestart={handleRestart} people={people} />;
   }
 
   return (
@@ -90,28 +90,28 @@ export default function StarterCard() {
                   from James Hoffman.
                 </p>
                 <div className="flex flex-col items-center mb-8">
-                  <p className="text-sm text-[#6c6c6c] mb-3">How many cups?</p>
+                  <p className="text-sm text-[#6c6c6c] mb-3">How many people?</p>
                   <div className="flex items-center gap-4">
                     <button
-                      onClick={() => setServings((s) => Math.max(1, s - 1))}
-                      disabled={servings === 1}
+                      onClick={() => setPeople((p) => Math.max(1, p - 1))}
+                      disabled={people === 1}
                       className="w-9 h-9 rounded-full border border-[#8FA967] text-[#8FA967] flex items-center justify-center disabled:opacity-30 hover:bg-[#8FA967] hover:text-white transition-colors"
                     >
                       <Minus className="w-4 h-4" />
                     </button>
                     <span className="text-2xl font-bold text-[#4a4a4a] w-6 text-center">
-                      {servings}
+                      {people}
                     </span>
                     <button
-                      onClick={() => setServings((s) => Math.min(4, s + 1))}
-                      disabled={servings === 4}
+                      onClick={() => setPeople((p) => Math.min(4, p + 1))}
+                      disabled={people === 4}
                       className="w-9 h-9 rounded-full border border-[#8FA967] text-[#8FA967] flex items-center justify-center disabled:opacity-30 hover:bg-[#8FA967] hover:text-white transition-colors"
                     >
                       <Plus className="w-4 h-4" />
                     </button>
                   </div>
                   <p className="text-xs text-[#9c9c9c] mt-2">
-                    {servings * 30}g coffee · {servings * 500}ml water
+                    {people * 15}g coffee · {people * 250}ml water
                   </p>
                 </div>
               </>


### PR DESCRIPTION
## Summary
- Adds a +/- cup selector (1–4) to the v60 welcome screen
- Scales all downstream values based on serving count: coffee grams and water ml in the inventory checklist, plus all three pour targets during brewing (bloom, step 2, total)

## Test plan
- [ ] Select 1–4 cups on welcome screen and confirm summary text updates live
- [ ] Hit Start and confirm inventory shows correct scaled amounts
- [ ] Start brewing and confirm step 1 bloom target, step 2 target, and step 3 total target all reflect the selected serving count